### PR TITLE
update deprecated _SCHEMA refs

### DIFF
--- a/components/centuryvspump/number/__init__.py
+++ b/components/centuryvspump/number/__init__.py
@@ -24,9 +24,8 @@ CenturyVSPumpDemandNumber = century_vs_pump_ns.class_(
     "CenturyVSPumpDemandNumber", cg.Component, number.Number
 )
 
-
 CONFIG_SCHEMA = cv.All(
-    number.NUMBER_SCHEMA.extend(cv.COMPONENT_SCHEMA)
+    number.number_schema(CenturyVSPumpDemandNumber).extend(cv.COMPONENT_SCHEMA)
     .extend(CenturyVSPumpItemSchema)
     .extend(
         {

--- a/components/centuryvspump/sensor/__init__.py
+++ b/components/centuryvspump/sensor/__init__.py
@@ -31,7 +31,7 @@ SENSOR_TYPE = century_vs_pump_ns.enum("Type")
 SENSOR_TYPES = {"rpm": SENSOR_TYPE.rpm, "custom": SENSOR_TYPE.custom}
 
 CONFIG_SCHEMA = cv.All(
-    sensor.SENSOR_SCHEMA.extend(cv.COMPONENT_SCHEMA)
+    sensor.sensor_schema(CenturyVSPumpSensor).extend(cv.COMPONENT_SCHEMA)
     .extend(CenturyVSPumpItemSchema)
     .extend(
         {

--- a/components/centuryvspump/switch/__init__.py
+++ b/components/centuryvspump/switch/__init__.py
@@ -26,7 +26,7 @@ CenturyVSPumpRunSwitch = century_vs_pump_ns.class_(
 
 
 CONFIG_SCHEMA = cv.All(
-    switch.SWITCH_SCHEMA.extend(cv.COMPONENT_SCHEMA)
+    switch.switch_schema(CenturyVSPumpRunSwitch).extend(cv.COMPONENT_SCHEMA)
     .extend(CenturyVSPumpItemSchema)
     .extend(
         {


### PR DESCRIPTION
This commit fixes #12  

These changes follow the pattern of *_schema() usage from esphome code, but are only tested for compilation, not in a working test rig (after doing some software prep, I discovered my older Superflo VS pump lacks support for RS485). 

Feel free to discard this PR in favor of a more comprehensive rewrite of the affected code: some of the previous ".extends()" calls may not be necessary given the esphome constructor operations.  Or, accept it as a patch to remove compilation warnings for now.